### PR TITLE
Migrate unit tests from JUnit 4 to 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,9 +37,7 @@
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
         <java.version>1.8</java.version>
 
-        <junit.vintage.version>5.3.2</junit.vintage.version>
-        <junit-jupiter.version>5.3.2</junit-jupiter.version>
-        <junit-platform.version>1.3.2</junit-platform.version>
+        <junit-jupiter.version>5.7.0</junit-jupiter.version>
     </properties>
 
     <developers>
@@ -66,17 +64,22 @@
         </repository>
     </distributionManagement>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.junit</groupId>
+				<artifactId>junit-bom</artifactId>
+				<version>${junit-jupiter.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>3.1.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -109,6 +112,12 @@
             <artifactId>common-utils</artifactId>
             <version>1.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                	<groupId>junit</groupId>
+                	<artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.jupiter-tools</groupId>
@@ -121,37 +130,26 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-engine</artifactId>
-            <version>${junit-platform.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit-platform.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.vintage.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Junit 5 -->

--- a/src/test/java/com/antkorwin/xsync/XMutexFactoryImplTest.java
+++ b/src/test/java/com/antkorwin/xsync/XMutexFactoryImplTest.java
@@ -11,7 +11,8 @@ import java.util.stream.IntStream;
 import com.antkorwin.commonutils.concurrent.ConcurrentSet;
 import com.antkorwin.commonutils.gc.GcUtils;
 import org.hibernate.validator.internal.util.ConcurrentReferenceHashMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -155,7 +156,8 @@ public class XMutexFactoryImplTest {
 		assertThat(key).isNotNull();
 	}
 
-	@Test(timeout = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK)
+	@Test
+	@Timeout(value = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK, unit = TimeUnit.MILLISECONDS)
 	public void testConcurrency() {
 		// Arrange
 		XMutexFactoryImpl<UUID> mutexFactory = new XMutexFactoryImpl<>();
@@ -202,8 +204,8 @@ public class XMutexFactoryImplTest {
 		}
 	}
 
-
-	@Test(timeout = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK)
+	@Test
+	@Timeout(value = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK, unit = TimeUnit.MILLISECONDS)
 	public void testWithCustomConcurrencySettingsWeakAndLevel() {
 		// Arrange
 		XMutexFactoryImpl<UUID> mutexFactory =

--- a/src/test/java/com/antkorwin/xsync/XMutexTest.java
+++ b/src/test/java/com/antkorwin/xsync/XMutexTest.java
@@ -1,10 +1,10 @@
 package com.antkorwin.xsync;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
-
 import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created on 17.06.2018.

--- a/src/test/java/com/antkorwin/xsync/XSyncTest.java
+++ b/src/test/java/com/antkorwin/xsync/XSyncTest.java
@@ -192,7 +192,7 @@ public class XSyncTest {
 
 		String key = "123456789";
 
-		List<Integer> results = new ArrayList<>();
+		List<Integer> results = new ArrayList<>(1);
 		AtomicInteger counter = new AtomicInteger(0);
 
 		StressTestRunner.test()
@@ -208,13 +208,17 @@ public class XSyncTest {
 			                } else {
 				                sync = xsyncSecond;
 			                }
-			                sync.execute(key, () -> results.add(1));
+			                sync.execute(key, () -> {
+						        if (results.isEmpty()) {
+							        results.add(0, 0);
+						        }
+			                	final int previousValue = results.get(0);
+			                	results.set(0, previousValue + 1);
+		                	});
 		                });
 
-		long sum = results.stream()
-		                  .mapToLong(i -> i == null ? 0 : (long)i)
-		                  .sum();
+		final int sum = results.get(0);
 
-		assertThat(sum).isNotEqualTo(ITERATION_COUNT);
+		assertThat(sum).isLessThan(ITERATION_COUNT);
 	}
 }

--- a/src/test/java/com/antkorwin/xsync/XSyncTest.java
+++ b/src/test/java/com/antkorwin/xsync/XSyncTest.java
@@ -1,5 +1,10 @@
 package com.antkorwin.xsync;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -9,15 +14,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
 import com.antkorwin.commonutils.concurrent.NonAtomicInt;
 import com.antkorwin.commonutils.concurrent.ThreadSleep;
 import com.jupiter.tools.stress.test.concurrency.ExecutionMode;
 import com.jupiter.tools.stress.test.concurrency.StressTestRunner;
-import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Created on 18.06.2018.
@@ -30,7 +33,8 @@ public class XSyncTest {
 	private static final int THREAD_CNT = 10_000_000;
 	private static final int ITERATION_COUNT = 100_000;
 
-	@Test(timeout = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK)
+	@Test
+	@Timeout(value = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK, unit = TimeUnit.MILLISECONDS)
 	public void testSyncBySingleKeyInConcurrency() {
 		// Arrange
 		XSync<UUID> xsync = new XSync<>();
@@ -50,7 +54,8 @@ public class XSyncTest {
 		assertThat(var.getValue()).isEqualTo(THREAD_CNT);
 	}
 
-	@Test(timeout = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK)
+	@Test
+	@Timeout(value = TIMEOUT_FOR_PREVENTION_OF_DEADLOCK, unit = TimeUnit.MILLISECONDS)
 	public void testSyncBySameValueOfKeyInConcurrency() {
 		// Arrange
 		XSync<UUID> xsync = new XSync<>();
@@ -129,13 +134,16 @@ public class XSyncTest {
 		assertThat(sum).isEqualTo(expectedSum);
 	}
 
-	@Test(expected = IndexOutOfBoundsException.class)
+	@Test
 	public void testThrowExceptionInFunction() throws Exception {
 		// Arrange
 		XSync<Integer> xSync = new XSync<>();
+
 		// Act
-		xSync.evaluate(123, () -> {
-			throw new IndexOutOfBoundsException();
+		assertThatExceptionOfType(IndexOutOfBoundsException.class).isThrownBy(() -> {
+			xSync.evaluate(123, () -> {
+				throw new IndexOutOfBoundsException();
+			});
 		});
 	}
 
@@ -175,7 +183,7 @@ public class XSyncTest {
 		assertThat(sum).isEqualTo(ITERATION_COUNT);
 	}
 
-	@Test(expected = Throwable.class)
+	@Test
 	public void xSyncWithDifferentMutexFactoriesDoesntLock() {
 
 		// making two synchronization primitives with individual mutex factories
@@ -204,9 +212,9 @@ public class XSyncTest {
 		                });
 
 		long sum = results.stream()
-		                  .mapToLong(i -> i)
+		                  .mapToLong(i -> i == null ? 0 : (long)i)
 		                  .sum();
 
-		assertThat(sum).isEqualTo(ITERATION_COUNT);
+		assertThat(sum).isNotEqualTo(ITERATION_COUNT);
 	}
 }


### PR DESCRIPTION
This leverages the bill of materials to simplify JUnit dependency management. It also removes all transitive dependencies on JUnit 4. Finally, it updates all tests to use JUnit 5.

Note that for the test `XSyncTest::xSyncWithDifferentMutexFactoriesDoesntLock`, it was expecting a `Throwable` to be thrown at any time. In practice, sometimes, this was an NPE and sometimes it was a failed assertion. I fixed the NPE, negated the assertion, and removed the expected exception.

Resolves: #7